### PR TITLE
config: Add chailove

### DIFF
--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -48,6 +48,7 @@ ADDONS = {
     'bsnes-mercury-performance': ('bsnes-mercury',              'Makefile',          '.',                 'target-libretro/jni', {'binary_dir': 'out', 'soname': 'bsnes_mercury_performance', 'jnisoname': 'libretro_bsnes_mercury_performance', 'cmake_options': 'profile=performance'}),
     'cap32':                     ('libretro-cap32',             'Makefile',          '.'  ,               'jni'),
     'desmume':                   ('desmume',                    'Makefile.libretro', 'desmume/src/frontend/libretro', 'desmume/src/frontend/libretro/jni'),
+    'chailove':                  ('libretro-chailove',          'Makefile',          '.',                 'jni'),
     #'dolphin':                   ('dolphin',                    'Makefile',          'Source/Core/DolphinLibretro', 'Source/Core/DolphinLibretro/jni', {'binary_dir': 'Source/Core/DolphinLibretro'}),  # Longrunning
     'dinothawr':                 ('Dinothawr',                  'Makefile',          '.',                 'jni'),
     'dosbox':                    ('dosbox-libretro',            'Makefile.libretro', '.',                 'jni'),


### PR DESCRIPTION
Include chailove to automatically keep the game addon up to date.

This requires: https://github.com/kodi-game/game.libretro.chailove/pull/2 to be merged first.

Unfortunately also the debug build needs to be fixed first (there are undefined symbols that prevent us from loading the compiled lib within the script).

```
vendor/freetype2/src/gzip/ftgzip.o: In function `inflate_codes_new': chailove/vendor/freetype2/src/gzip/infcodes.c:74: undefined reference to `z_verbose'
vendor/freetype2/src/gzip/ftgzip.o: In function `inflate_codes': chailove/vendor/freetype2/src/gzip/infcodes.c:129: undefined reference to `z_verbose'
chailove/vendor/freetype2/src/gzip/infcodes.c:150: undefined reference to `z_verbose'
chailove/vendor/freetype2/src/gzip/infcodes.c:165: undefined reference to `z_verbose'
chailove/vendor/freetype2/src/gzip/infcodes.c:195: undefined reference to `z_verbose'
chailove/vendor/freetype2/src/gzip/infcodes.c:219: undefined reference to `z_error'
vendor/freetype2/src/gzip/ftgzip.o: In function `inflate_codes_free': chailove/vendor/freetype2/src/gzip/infcodes.c:249: undefined reference to `z_verbose'
vendor/freetype2/src/gzip/ftgzip.o: In function `inflate_blocks_reset': chailove/vendor/freetype2/src/gzip/infblock.c:84: undefined reference to `z_verbose'
vendor/freetype2/src/gzip/ftgzip.o: In function `inflate_blocks_new': chailove/vendor/freetype2/src/gzip/infblock.c:113: undefined reference to `z_verbose'
vendor/freetype2/src/gzip/ftgzip.o: In function `inflate_blocks': chailove/vendor/freetype2/src/gzip/infblock.c:145: undefined reference to `z_verbose'
chailove/vendor/freetype2/src/gzip/infblock.c:153: undefined reference to `z_verbose'
vendor/freetype2/src/gzip/ftgzip.o:chailove/vendor/freetype2/src/gzip/infblock.c:172: more undefined references to `z_verbose' follow
collect2: error: ld returned 1 exit status
```
@RobLoach is this something you could take care of? Otherwise I'll try to look into it when I find the time.