### PR TITLE
Remove <supports_mouse> and <supports_keyboard> from addon.xml

### DIFF
--- a/templates/addon/game.libretro.{{ game.name }}/addon.xml.in.j2
+++ b/templates/addon/game.libretro.{{ game.name }}/addon.xml.in.j2
@@ -19,8 +19,6 @@
 		<extensions>{{ system_info.extensions | join('|') | e }}</extensions>
 		<supports_vfs>{{ 'false' if system_info.need_fullpath | default('true') else 'true' }}</supports_vfs>
 		<supports_standalone>{{ system_info.supports_no_game | default('false') | lower }}</supports_standalone>
-		<supports_keyboard>{{ xml.addon.extension[0].supports_keyboard | default('false') | lower }}</supports_keyboard>
-		<supports_mouse>{{ xml.addon.extension[0].supports_mouse | default('false') | lower }}</supports_mouse>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		{% set summary = addon_name %}


### PR DESCRIPTION
In the Game API v1.0.36, support was added for a topology.xml file that describes the ports on the virtual console. Mouse and keyboard are included in the topology, so they are no longer needed in addon.xml.

For https://github.com/xbmc/xbmc/pull/13499.