### PR TITLE
Add MinGW build system to windows depends

### DIFF
--- a/templates/addon/depends/windows/mingw/01-make.bat.in.patch
+++ b/templates/addon/depends/windows/mingw/01-make.bat.in.patch
@@ -1,0 +1,8 @@
+--- /dev/null
++++ b/make.bat.in
+@@ -0,0 +1,5 @@
++@ECHO OFF
++SETLOCAL
++
++SET PATH=@CMAKE_CURRENT_SOURCE_DIR@\@MINGW_PATH@\bin;@CMAKE_CURRENT_SOURCE_DIR@\usr\bin;%PATH%
++make.exe %*

--- a/templates/addon/depends/windows/mingw/02-MinGWConfig.cmake.in.patch
+++ b/templates/addon/depends/windows/mingw/02-MinGWConfig.cmake.in.patch
@@ -1,0 +1,4 @@
+--- /dev/null
++++ b/MinGWConfig.cmake.in
+@@ -0,0 +1,1 @@
++set(MINGW_MAKE @CMAKE_CURRENT_SOURCE_DIR@/@MINGW_PATH@/bin/make.bat)

--- a/templates/addon/depends/windows/mingw/CMakeLists.txt
+++ b/templates/addon/depends/windows/mingw/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.4)
+
+project(mingw)
+
+foreach(repo msys mingw32 mingw64)
+  if(${repo} STREQUAL msys)
+    file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/etc/pacman.d/mirrorlist.${repo} "Server = http://mirrors.kodi.tv/build-deps/win32/msys2/repos/${repo}2/$arch\n")
+  else()
+    file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/etc/pacman.d/mirrorlist.${repo} "Server = http://mirrors.kodi.tv/build-deps/win32/msys2/repos/${repo}\n")
+  endif()
+endforeach()
+
+include(CheckSymbolExists)
+check_symbol_exists(_X86_ "Windows.h" _X86_)
+check_symbol_exists(_AMD64_ "Windows.h" _AMD64_)
+
+if(_X86_)
+   set(HOST mingw-w64-i686)
+   set(MINGW_PATH "mingw32")
+elseif(_AMD64_)
+   set(HOST mingw-w64-x86_64)
+   set(MINGW_PATH "mingw64")
+else()
+   message(FATAL_ERROR "Unsupported architecture")
+endif()
+
+execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/usr/bin/bash.exe --login -c "pacman-key --init")
+execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/usr/bin/bash.exe --login -c "pacman --noconfirm -S make ${HOST}-gcc")
+
+file(GLOB_RECURSE shared_libs ${CMAKE_CURRENT_SOURCE_DIR}/${MINGW_PATH}/*.dll.a)
+file(REMOVE ${shared_libs})
+
+configure_file(MinGWConfig.cmake.in MinGWConfig.cmake @ONLY)
+configure_file(make.bat.in ${CMAKE_CURRENT_SOURCE_DIR}/${MINGW_PATH}/bin/make.bat @ONLY)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/MinGWConfig.cmake DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/templates/addon/depends/windows/mingw/mingw.txt
+++ b/templates/addon/depends/windows/mingw/mingw.txt
@@ -1,0 +1,1 @@
+mingw http://mirrors.kodi.tv/build-deps/win32/msys2/msys2-base-x86_64-20161025.tar.xz


### PR DESCRIPTION
MSYS/MinGW was removed from Kodi (except for some ffmpeg stuff), so we need to provide MinGW in our add-ons.

Tested with 2048 and Snes9x on Windows.

In the future, it would be nice to allow custom CMake on windows so that we can build with MSVCC instead of MinGW for debug symbols: https://github.com/Rechi/game.libretro.2048/commit/8cf215b

Imported from: https://github.com/kodi-game/game.libretro.2048/compare/master...Rechi:addFUCKINGstupidMingwBuildSystemInsteadOfMSVCwithDebugSymbols