### PR TITLE
templates: Add README.md, .travis.yml & appveyor.yml

### DIFF
--- a/templates/addon/.travis.yml.j2
+++ b/templates/addon/.travis.yml.j2
@@ -1,0 +1,51 @@
+language: cpp
+
+#
+# Define the build matrix
+#
+# Travis defaults to building on Ubuntu Precise when building on
+# Linux. We need Trusty in order to get up to date versions of
+# cmake and g++.
+#
+env:
+  global:
+    - app_id=game.libretro.{{ game.name }}
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: gcc
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: clang
+    - os: osx
+      osx_image: xcode7.3
+    # Disabled due to build error: "ld: library not found for -lgcc_s.10.4"
+    #- os: osx
+    #  osx_image: xcode6.4
+
+#
+# Some of the OS X images don't have cmake, contrary to what people
+# on the Internet say
+#
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew update        ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew install cmake ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew upgrade cmake || true; fi
+
+#
+# The addon source is automatically checked out in $TRAVIS_BUILD_DIR,
+# we'll put the Kodi source on the same level
+#
+before_script:
+  - cd $TRAVIS_BUILD_DIR/..
+  - git clone --depth=1 https://github.com/xbmc/xbmc.git
+  - cd ${app_id} && mkdir build && cd build
+  - mkdir -p definition/${app_id}
+  - echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt
+  - cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons
+
+script: make

--- a/templates/addon/README.md.j2
+++ b/templates/addon/README.md.j2
@@ -1,0 +1,6 @@
+# game.libretro.{{ game.name }} addon for Kodi
+
+This is a [Kodi](http://kodi.tv) game addon for {{ libretro_info.display_name | default(xml.addon.name) | default(system_info.name) | default(game.name) }}.
+
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.{{ game.name }}.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.{{ game.name }})
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.{{ game.name }}?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-{{ game.name }})

--- a/templates/addon/appveyor.yml.j2
+++ b/templates/addon/appveyor.yml.j2
@@ -1,0 +1,29 @@
+version: BuildNr.{build}
+
+image: Visual Studio 2015
+
+shallow_clone: true
+
+clone_folder: c:\projects\game.libretro.{{ game.name }}
+
+environment:
+  app_id: game.libretro.{{ game.name }}
+
+  matrix:
+    - GENERATOR: "Visual Studio 14"
+      CONFIG: Release
+    - GENERATOR: "Visual Studio 14 Win64"
+      CONFIG: Release
+
+build_script:
+  - cd ..
+  - git clone --depth=1 https://github.com/xbmc/xbmc.git
+  - mklink /j xbmc\project\BuildDependencies\msys64 C:\msys64
+  - cd %app_id%
+  - mkdir build
+  - cd build
+  - mkdir -p definition\%app_id%
+  - echo %app_id% %APPVEYOR_BUILD_FOLDER% %APPVEYOR_REPO_COMMIT% > definition\%app_id%\%app_id%.txt
+  - SET PATH=C:\Program Files (x86)\CMake\bin;C:\msys64\bin;C:\msys64\usr\bin;%PATH%
+  - cmake -T host=x64 -G "%GENERATOR%" -DADDONS_TO_BUILD=%app_id% -DCMAKE_BUILD_TYPE=%CONFIG% -DADDONS_DEFINITION_DIR=%APPVEYOR_BUILD_FOLDER%/build/definition -DADDON_SRC_PREFIX=../.. -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons
+  - cmake --build . --config %CONFIG% --target %app_id%


### PR DESCRIPTION
This generates the READMEs and CI configs and fixes:
- All links to the Travis CI build status badges.
- The Travis CI builds that fail on osx/xcode6.4 with "ld: library not found for -lgcc_s.10.4" by disabling that job.
- Some c&p errors for build status badge links.
- Project names in the README.

There are a few projects where the Appveyor status badge doesn't point to kodi-game:
- [ ] 2048: Appveyor from notspiff instead of kodi-game
- [ ] snes9x: Appveyor from garbear instead of kodi-game
- [ ] hatari: Appveyor from garbear instead of kodi-game

@garbear / @notspiff Could you please move the project in Appveyor over to kodi-game?

New projects where we need to enable Travis CI/Appveyor.
- [ ] fbalpha2012
- [ ] pokemini
- [ ] sameboy
- [ ] uae
- [ ] vice

Generated patch:

```
commit 0c29b6c1c899ff6048bad8d02600b93329aed8bc
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:00 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:00 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 051f887..08f48c4 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.2048 addon for Kodi
 
-This is a [Kodi](http://kodi.tv) addon for the game 2048.
+This is a [Kodi](http://kodi.tv) game addon for 2048.
 
 [![Build Status](https://travis-ci.org/kodi-game/game.libretro.2048.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.2048)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/notspiff/game.libretro.2048?svg=true)](https://ci.appveyor.com/project/notspiff/game-libretro-2048)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.2048?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-2048)
commit 0d3d057e1b62ab973e211e171a371189057c2971
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:00 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:00 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 16b2e23..0df55e7 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.4do addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for 3DO.
+This is a [Kodi](http://kodi.tv) game addon for The 3DO Company - 3DO (4DO).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.4do?branch=master)](https://travis-ci.org/kodi-game/game.libretro.4do)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.4do.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.4do)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.4do?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-4do)
commit 6ef878a19f2c08986f7fe5c43d6d2ae1a25e789a
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:00 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:00 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 9959137..734b9c9 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.beetle-bsnes addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for SNES.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - SNES / Famicom (Beetle bsnes).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-bsnes?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-bsnes)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-bsnes.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-bsnes)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.beetle-bsnes?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-beetle-bsnes)
commit 1f35025ba6313d605ee5fda4e71e50dbe3cd8fa9
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:01 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:01 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 0046e52..b98c77a 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.beetle-gba addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Gameboy Advance.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - Game Boy Advance (Beetle GBA).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-gba?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-gba)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-gba.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-gba)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.beetle-gba?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-beetle-gba)
commit e888d6590b3f4c894c692f820772897a9526f60d
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:01 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:01 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 96422b3..b20220a 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.beetle-lynx addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Lynx.
+This is a [Kodi](http://kodi.tv) game addon for Atari - Lynx (Beetle Handy).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-lynx?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-lynx)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-lynx.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-lynx)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.beetle-lynx?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-beetle-lynx)
commit 6655b57f336ce06ad7bbb5c88ffbb3339b09660e
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:01 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:01 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 281a3fc..edc8def 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.beetle-ngp addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for NeoGeo Pocket.
+This is a [Kodi](http://kodi.tv) game addon for SNK - Neo Geo Pocket / Color (Beetle NeoPop).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-ngp?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-ngp)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-ngp.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-ngp)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.beetle-ngp?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-beetle-ngp)
commit d323471269fbc18b86b9a09b1f2733fc834ac546
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:01 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:01 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index b47a07a..4edbc09 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.beetle-pce-fast addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for PC Engine
+This is a [Kodi](http://kodi.tv) game addon for NEC - PC Engine / CD (Beetle PCE FAST).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-pce-fast?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-pce-fast)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-pce-fast.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-pce-fast)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.beetle-pce-fast?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-beetle-pce-fast)
commit 6b2ec43a966ef09b6c5933939966c13b61e766d7
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:01 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:01 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index d84fbf4..0e83697 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.beetle-pcfx addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for PC-FX.
+This is a [Kodi](http://kodi.tv) game addon for NEC - PC-FX (Beetle PC-FX).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-pcfx?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-pcfx)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-pcfx.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-pcfx)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.beetle-pcfx?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-beetle-pcfx)
commit 86fdee38eeacece31ed699d142580a7a9ba5857e
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:01 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:01 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 09c204c..636d2a0 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.beetle-psx addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Playstation.
+This is a [Kodi](http://kodi.tv) game addon for Sony - PlayStation (Beetle PSX).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-psx?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-psx)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-psx.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-psx)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.beetle-psx?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-beetle-psx)
commit b896f69d5b5fd1c050ee91d118e8bf6825f8170b
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:01 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:01 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 4dd86da..01985ca 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.beetle-saturn addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Saturn.
+This is a [Kodi](http://kodi.tv) game addon for Sega - Saturn (Beetle Saturn).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-saturn?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-saturn)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-saturn.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-saturn)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.beetle-saturn?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-beetle-saturn)
commit f14a06c3d61924cd172d89f786e322ad3c2ee677
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:01 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:01 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 4f5ff3e..e110fba 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.beetle-supergrafx addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for SuperGrafX.
+This is a [Kodi](http://kodi.tv) game addon for NEC - PC Engine SuperGrafx (Beetle SGX).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-supergrafx?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-supergrafx)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-supergrafx.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-supergrafx)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.beetle-supergrafx?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-beetle-supergrafx)
commit df7d31c16c2a6df3a31960b99b410a439e959ad8
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:01 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:01 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 0dc8faf..be58088 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.beetle-vb addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Virtual Boy.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - Virtual Boy (Beetle VB).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-vb?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-vb)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-vb.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-vb)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.beetle-vb?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-beetle-vb)
commit 006540f41281478fd2b6fa8f4c955c8d013233b3
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:01 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:01 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 34e2ef6..8089e2d 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.beetle-wswan addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for WonderSwan.
+This is a [Kodi](http://kodi.tv) game addon for Bandai - WonderSwan/Color (Beetle Cygne).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-wswan?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-wswan)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.beetle-wswan.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.beetle-wswan)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.beetle-wswan?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-beetle-wswan)
commit 0b356b6d552b77e0a575bc72e79b7f7cc4a3c556
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:02 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:02 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 61f409a..bdfe5c0 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.bluemsx addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for MSX.
+This is a [Kodi](http://kodi.tv) game addon for MSX/SVI/ColecoVision/SG-1000 (blueMSX).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.bluemsx?branch=master)](https://travis-ci.org/kodi-game/game.libretro.bluemsx)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.bluemsx.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.bluemsx)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.bluemsx?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-bluemsx)
commit fd1f5c51c8c709b79a51abf79130291bc9fea1cd
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:02 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:02 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 89a127e..d016ea0 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.bnes addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for NES.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - NES / Famicom (bnes).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.bnes?branch=master)](https://travis-ci.org/kodi-game/game.libretro.bnes)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.bnes.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.bnes)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.bnes?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-bnes)
commit 88dd2415844b6e33cc23832d09a1cbfce1c10dfb
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:02 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:02 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 37872c3..bcaa06f 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.bsnes-mercury-accuracy addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for SNES.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - SNES / Famicom (bsnes-mercury Accuracy).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.bsnes-mercury-accuracy?branch=master)](https://travis-ci.org/kodi-game/game.libretro.4do)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.bsnes-mercury-accuracy?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-4do)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.bsnes-mercury-accuracy.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.bsnes-mercury-accuracy)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.bsnes-mercury-accuracy?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-bsnes-mercury-accuracy)
commit d6e3f69fac5e2483d4f1a31c458d60cd3d56ece2
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:02 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:02 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 8d4e18a..b637d4b 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.bsnes-mercury-balanced addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for SNES.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - SNES / Famicom (bsnes-mercury Balanced).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.bsnes-mercury-balanced?branch=master)](https://travis-ci.org/kodi-game/game.libretro.4do)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.bsnes-mercury-balanced?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-4do)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.bsnes-mercury-balanced.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.bsnes-mercury-balanced)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.bsnes-mercury-balanced?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-bsnes-mercury-balanced)
commit 69af22a0e01253769bc2d01ffd67c05d71e968af
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:02 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:02 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 83de9db..c68a088 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.bsnes-mercury-performance addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for SNES.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - SNES / Famicom (bsnes-mercury Performance).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.bsnes-mercury-performance?branch=master)](https://travis-ci.org/kodi-game/game.libretro.4do)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.bsnes-mercury-performance?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-4do)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.bsnes-mercury-performance.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.bsnes-mercury-performance)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.bsnes-mercury-performance?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-bsnes-mercury-performance)
commit ce7f31f3b5ba2c69df0d01b70f5c961e86e6e169
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:02 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:02 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 7363b8c..a0273ef 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.cap32 addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Caprice32.
+This is a [Kodi](http://kodi.tv) game addon for Amstrad - CPC (Caprice32).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.cap32?branch=master)](https://travis-ci.org/kodi-game/game.libretro.cap32)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.cap32.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.cap32)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.cap32?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-cap32)
commit c55bc118a28b79c44f9c016e5311d0c3cfe48ab1
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:02 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:02 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 6d5be92..54bc18f 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.chailove addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for [ChaiLove](https://github.com/libretro/libretro-chailove).
+This is a [Kodi](http://kodi.tv) game addon for ChaiLove.
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.chailove?branch=master)](https://travis-ci.org/kodi-game/game.libretro.chailove)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.chailove.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.chailove)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.chailove?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-chailove)
commit 9fa6971c13eca7698960645adf391f5e92c4a5a2
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:02 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:02 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index bbaf4f9..f249675 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.desmume addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Nintendo DS.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - DS (DeSmuME).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.desmume?branch=master)](https://travis-ci.org/kodi-game/game.libretro.desmume)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.desmume.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.desmume)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.desmume?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-desmume)
commit ebeb7e8c2a892280e32854a10f3a3a181a7009e0
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:02 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:02 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 66a4813..1e28d4c 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.dinothawr addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon.
+This is a [Kodi](http://kodi.tv) game addon for Dinothawr.
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.dinothawr?branch=master)](https://travis-ci.org/kodi-game/game.libretro.dinothawr)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.dinothawr.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.dinothawr)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.dinothawr?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-dinothawr)
commit 65065536b734d2c72bdb9f4006c4ebc996840fb9
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:03 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:03 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index b91f09c..c93ca65 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.dosbox addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for PC DOS games.
+This is a [Kodi](http://kodi.tv) game addon for DOS (DOSBox).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.dosbox?branch=master)](https://travis-ci.org/kodi-game/game.libretro.dosbox)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.dosbox.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.dosbox)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.dosbox?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-dosbox)
commit 44777dd3518bbc20055ee20827c8528d517c945e
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:03 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:03 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 33dd5e8..58d6ae5 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.fbalpha addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for arcade machines.
+This is a [Kodi](http://kodi.tv) game addon for Arcade (FB Alpha).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.fbalpha?branch=master)](https://travis-ci.org/kodi-game/game.libretro.fbalpha)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.fbalpha.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.fbalpha)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.fbalpha?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-fbalpha)
commit b830ca217dcc30a0594f15f4621bce85c5fb69e9
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:03 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:03 2018 +0100

    Updated by kodi-game-scripting

diff --git a/.travis.yml b/.travis.yml
new file mode 100644
index 0000000..b72a9a2
--- /dev/null
+++ b/.travis.yml
@@ -0,0 +1,50 @@
+language: cpp
+
+#
+# Define the build matrix
+#
+# Travis defaults to building on Ubuntu Precise when building on
+# Linux. We need Trusty in order to get up to date versions of
+# cmake and g++.
+#
+env:
+  global:
+    - app_id=game.libretro.fbalpha2012
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: gcc
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: clang
+    - os: osx
+      osx_image: xcode7.3
+    - os: osx
+      osx_image: xcode6.4
+
+#
+# Some of the OS X images don't have cmake, contrary to what people
+# on the Internet say
+#
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew update        ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew install cmake ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew upgrade cmake || true; fi
+
+#
+# The addon source is automatically checked out in $TRAVIS_BUILD_DIR,
+# we'll put the Kodi source on the same level
+#
+before_script:
+  - cd $TRAVIS_BUILD_DIR/..
+  - git clone --depth=1 https://github.com/xbmc/xbmc.git
+  - cd ${app_id} && mkdir build && cd build
+  - mkdir -p definition/${app_id}
+  - echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt
+  - cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons
+
+script: make
diff --git a/README.md b/README.md
new file mode 100644
index 0000000..eaf2694
--- /dev/null
+++ b/README.md
@@ -0,0 +1,6 @@
+# game.libretro.fbalpha2012 addon for Kodi
+
+This is a [Kodi](http://kodi.tv) game addon for Arcade (FB Alpha 2012).
+
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.fbalpha2012.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.fbalpha2012)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.fbalpha2012?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-fbalpha2012)
diff --git a/appveyor.yml b/appveyor.yml
new file mode 100644
index 0000000..e6702f1
--- /dev/null
+++ b/appveyor.yml
@@ -0,0 +1,29 @@
+version: BuildNr.{build}
+
+image: Visual Studio 2015
+
+shallow_clone: true
+
+clone_folder: c:\projects\game.libretro.fbalpha2012
+
+environment:
+  app_id: game.libretro.fbalpha2012
+
+  matrix:
+    - GENERATOR: "Visual Studio 14"
+      CONFIG: Release
+    - GENERATOR: "Visual Studio 14 Win64"
+      CONFIG: Release
+
+build_script:
+  - cd ..
+  - git clone --depth=1 https://github.com/xbmc/xbmc.git
+  - mklink /j xbmc\project\BuildDependencies\msys64 C:\msys64
+  - cd %app_id%
+  - mkdir build
+  - cd build
+  - mkdir -p definition\%app_id%
+  - echo %app_id% %APPVEYOR_BUILD_FOLDER% %APPVEYOR_REPO_COMMIT% > definition\%app_id%\%app_id%.txt
+  - SET PATH=C:\Program Files (x86)\CMake\bin;C:\msys64\bin;C:\msys64\usr\bin;%PATH%
+  - cmake -T host=x64 -G "%GENERATOR%" -DADDONS_TO_BUILD=%app_id% -DCMAKE_BUILD_TYPE=%CONFIG% -DADDONS_DEFINITION_DIR=%APPVEYOR_BUILD_FOLDER%/build/definition -DADDON_SRC_PREFIX=../.. -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons
+  - cmake --build . --config %CONFIG% --target %app_id%
commit 72395a4e34db5abe1b3dab4141b0247bb53184f9
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:03 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:03 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index ebfb932..e6ee3b1 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.fceumm addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for NES.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - NES / Famicom (FCEUmm).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.fceumm?branch=master)](https://travis-ci.org/kodi-game/game.libretro.fceumm)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.fceumm.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.fceumm)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.fceumm?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-fceumm)
commit fa41235e8d3f0d60dfa095a58e61785d14ba5451
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:03 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:03 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index e7b7be8..bb1dc39 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.fmsx addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for MSX.
+This is a [Kodi](http://kodi.tv) game addon for Microsoft - MSX (fMSX).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.fmsx?branch=master)](https://travis-ci.org/kodi-game/game.libretro.fmsx)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.fmsx.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.fmsx)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.fmsx?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-fmsx)
commit 1d2c6b368795e7b22327e3930f83ff90079ea845
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:03 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:03 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index a406844..86cd444 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.fuse addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Spectrum.
+This is a [Kodi](http://kodi.tv) game addon for ZX Spectrum (Fuse).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.fuse?branch=master)](https://travis-ci.org/kodi-game/game.libretro.fuse)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.fuse.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.fuse)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.fuse?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-fuse)
commit 89a5c14fb42b65e05e107b65d65f1a40c4238390
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:03 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:03 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index bd1171f..f8d1b6a 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.gambatte addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Game Boy Color.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - Game Boy / Color (Gambatte).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.gambatte?branch=master)](https://travis-ci.org/kodi-game/game.libretro.gambatte)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.gambatte.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.gambatte)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.gambatte?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-gambatte)
commit dc86980e1c4322918da5d30c54d077a952dd58e4
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:03 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:03 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 7c2c0b1..73e2c86 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.genplus addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Sega Genesis.
+This is a [Kodi](http://kodi.tv) game addon for Sega - MS/GG/MD/CD (Genesis Plus GX).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.genplus?branch=master)](https://travis-ci.org/kodi-game/game.libretro.genplus)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.genplus.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.genplus)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.genplus?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-genplus)
commit dd0b2913ab68de3fbbe30052a9c8e26f6a1501c4
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:03 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:03 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 9c30442..efbd90a 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.gw addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Game&Watch.
+This is a [Kodi](http://kodi.tv) game addon for Handheld Electronic (GW).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.gw?branch=master)](https://travis-ci.org/kodi-game/game.libretro.gw)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.gw.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.gw)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.gw?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-gw)
commit 030257794b8bc10b2c373b42cbeb7b5f3ab7e768
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:04 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:04 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index b61b49e..181a642 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.handy addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Atari Lynx.
+This is a [Kodi](http://kodi.tv) game addon for Atari - Lynx (Handy).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.handy?branch=master)](https://travis-ci.org/kodi-game/game.libretro.handy)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.handy.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.handy)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.handy?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-handy)
commit f066dc5aa8716ceca6f1df4ec376148ca4ae9883
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:04 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:04 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 0c54e0c..8fc9a85 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.hatari addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Atari ST/STE/TT/Falcon.
+This is a [Kodi](http://kodi.tv) game addon for Atari - ST/STE/TT/Falcon (Hatari).
 
 [![Build Status](https://travis-ci.org/kodi-game/game.libretro.hatari.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.hatari)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/garbear/game.libretro.hatari?svg=true)](https://ci.appveyor.com/project/garbear/game-libretro-hatari)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.hatari?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-hatari)
commit e9bac3092e365374645474aa6114ba3dff3a38ee
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:04 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:04 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index ffbdc48..e756105 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.lutro addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon.
+This is a [Kodi](http://kodi.tv) game addon for Lua Engine (Lutro).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.lutro?branch=master)](https://travis-ci.org/kodi-game/game.libretro.lutro)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.lutro.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.lutro)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.lutro?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-lutro)
commit 5226011cf244778dd0d4aec9030227a0a9d66fee
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:04 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:04 2018 +0100

    Updated by kodi-game-scripting

diff --git a/.travis.yml b/.travis.yml
index dffa7ad..c0ea7f6 100644
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
       compiler: clang
     - os: osx
       osx_image: xcode7.3
+    - os: osx
+      osx_image: xcode6.4
 
 #
 # Some of the OS X images don't have cmake, contrary to what people
diff --git a/README.md b/README.md
index 61b6086..2886823 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.melonds addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Nintendo DS.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - DS (melonDS).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.melonds?branch=master)](https://travis-ci.org/kodi-game/game.libretro.melonds)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.melonds.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.melonds)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.melonds?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-melonds)
commit 4ba109e427576d11a5786ae6f24ab9c74ebb5ac9
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:04 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:04 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index bdf09f5..cc7adb2 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.meteor addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Gameboy Advance.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - Game Boy Advance (Meteor).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.meteor?branch=master)](https://travis-ci.org/kodi-game/game.libretro.meteor)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.meteor.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.meteor)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.meteor?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-meteor)
commit 292295af6c4bec54f56850cd08ea429f301d2e38
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:04 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:04 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 2875637..4074cd3 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.mgba addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Gameboy Advance.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - Game Boy Advance (mGBA).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.mgba?branch=master)](https://travis-ci.org/kodi-game/game.libretro.mgba)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.mgba.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.mgba)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.mgba?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-mgba)
commit 152adede2c59e3d6f3bc03a85fcf84b2fe2cf501
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:04 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:04 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index af4aaaf..d47147b 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.mrboom addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon.
+This is a [Kodi](http://kodi.tv) game addon for Mr.Boom (Bomberman).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.mrboom?branch=master)](https://travis-ci.org/kodi-game/game.libretro.mrboom)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.mrboom.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.mrboom)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.mrboom?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-mrboom)
commit cb7e54b0f726b0c74952e7b30617807cb2c371b1
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:04 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:04 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 2803716..b0e458c 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.mupen64plus addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Nintendo 64.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - Nintendo 64 (Mupen64Plus).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.mupen64plus?branch=master)](https://travis-ci.org/kodi-game/game.libretro.mupen64plus)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.mupen64plus.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.mupen64plus)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.mupen64plus?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-mupen64plus)
commit b986e62a77a8a8c23a5b29c0370f6a404fd4ac6f
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:04 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:04 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index b4b5d22..792d584 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.nestopia addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for NES.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - NES / Famicom (Nestopia UE).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.nestopia?branch=master)](https://travis-ci.org/kodi-game/game.libretro.nestopia)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.nestopia.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.nestopia)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.nestopia?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-nestopia)
commit 1661aa4aadf36b8c7b9aad60ee08aa355394537a
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:05 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:05 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 0c5f6f1..414b99e 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.nx addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for NX Engine.
+This is a [Kodi](http://kodi.tv) game addon for Cave Story (NXEngine).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.nx?branch=master)](https://travis-ci.org/kodi-game/game.libretro.nx)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.nx.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.nx)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.nx?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-nx)
commit 592d020ca1f9cd33cb0c4196b64329f022447f5f
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:05 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:05 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 1d0cdf2..2d50a88 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.o2em addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Oddyssey 2.
+This is a [Kodi](http://kodi.tv) game addon for Magnavox - Odyssey2 / Phillips Videopac+ (O2EM).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.o2em?branch=master)](https://travis-ci.org/kodi-game/game.libretro.o2em)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.o2em.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.o2em)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.o2em?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-o2em)
commit e46701e3aa11778b9f2c6b1b7dcfb187d85d39ef
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:05 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:05 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index b044900..765d3d9 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.pcem addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon.
+This is a [Kodi](http://kodi.tv) game addon for PC (PCem).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.pcem?branch=master)](https://travis-ci.org/kodi-game/game.libretro.pcem)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.pcem.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.pcem)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.pcem?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-pcem)
commit 2d0259479871ffae379bdd4259ae70de28c33331
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:05 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:05 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
new file mode 100644
index 0000000..1fb3428
--- /dev/null
+++ b/README.md
@@ -0,0 +1,6 @@
+# game.libretro.pcsx-rearmed addon for Kodi
+
+This is a [Kodi](http://kodi.tv) game addon for Sony - PlayStation (PCSX ReARMed).
+
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.pcsx-rearmed.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.pcsx-rearmed)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.pcsx-rearmed?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-pcsx-rearmed)
commit 8ae5ab6961084c7ba0c4f1eccd7fc4a9ddbd2d78
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:05 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:05 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 4590fda..e3663fa 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.picodrive addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Genesis.
+This is a [Kodi](http://kodi.tv) game addon for Sega - MS/MD/CD/32X (PicoDrive).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.picodrive?branch=master)](https://travis-ci.org/kodi-game/game.libretro.picodrive)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.picodrive.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.picodrive)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.picodrive?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-picodrive)
commit b21c0088391400c1aa11db222c9f60e704c204f0
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:05 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:05 2018 +0100

    Updated by kodi-game-scripting

diff --git a/.travis.yml b/.travis.yml
new file mode 100644
index 0000000..31dbab2
--- /dev/null
+++ b/.travis.yml
@@ -0,0 +1,50 @@
+language: cpp
+
+#
+# Define the build matrix
+#
+# Travis defaults to building on Ubuntu Precise when building on
+# Linux. We need Trusty in order to get up to date versions of
+# cmake and g++.
+#
+env:
+  global:
+    - app_id=game.libretro.pokemini
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: gcc
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: clang
+    - os: osx
+      osx_image: xcode7.3
+    - os: osx
+      osx_image: xcode6.4
+
+#
+# Some of the OS X images don't have cmake, contrary to what people
+# on the Internet say
+#
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew update        ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew install cmake ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew upgrade cmake || true; fi
+
+#
+# The addon source is automatically checked out in $TRAVIS_BUILD_DIR,
+# we'll put the Kodi source on the same level
+#
+before_script:
+  - cd $TRAVIS_BUILD_DIR/..
+  - git clone --depth=1 https://github.com/xbmc/xbmc.git
+  - cd ${app_id} && mkdir build && cd build
+  - mkdir -p definition/${app_id}
+  - echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt
+  - cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons
+
+script: make
diff --git a/README.md b/README.md
new file mode 100644
index 0000000..29cefc7
--- /dev/null
+++ b/README.md
@@ -0,0 +1,6 @@
+# game.libretro.pokemini addon for Kodi
+
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - Pokémon Mini (PokeMini).
+
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.pokemini.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.pokemini)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.pokemini?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-pokemini)
diff --git a/appveyor.yml b/appveyor.yml
new file mode 100644
index 0000000..bd1847c
--- /dev/null
+++ b/appveyor.yml
@@ -0,0 +1,29 @@
+version: BuildNr.{build}
+
+image: Visual Studio 2015
+
+shallow_clone: true
+
+clone_folder: c:\projects\game.libretro.pokemini
+
+environment:
+  app_id: game.libretro.pokemini
+
+  matrix:
+    - GENERATOR: "Visual Studio 14"
+      CONFIG: Release
+    - GENERATOR: "Visual Studio 14 Win64"
+      CONFIG: Release
+
+build_script:
+  - cd ..
+  - git clone --depth=1 https://github.com/xbmc/xbmc.git
+  - mklink /j xbmc\project\BuildDependencies\msys64 C:\msys64
+  - cd %app_id%
+  - mkdir build
+  - cd build
+  - mkdir -p definition\%app_id%
+  - echo %app_id% %APPVEYOR_BUILD_FOLDER% %APPVEYOR_REPO_COMMIT% > definition\%app_id%\%app_id%.txt
+  - SET PATH=C:\Program Files (x86)\CMake\bin;C:\msys64\bin;C:\msys64\usr\bin;%PATH%
+  - cmake -T host=x64 -G "%GENERATOR%" -DADDONS_TO_BUILD=%app_id% -DCMAKE_BUILD_TYPE=%CONFIG% -DADDONS_DEFINITION_DIR=%APPVEYOR_BUILD_FOLDER%/build/definition -DADDON_SRC_PREFIX=../.. -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons
+  - cmake --build . --config %CONFIG% --target %app_id%
commit a2121b7ba0e8d1d1281635220d46704ed1220987
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:05 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:05 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index fccd4ba..da853a1 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.prboom addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon.
+This is a [Kodi](http://kodi.tv) game addon for Doom (PrBoom).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.prboom?branch=master)](https://travis-ci.org/kodi-game/game.libretro.prboom)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.prboom.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.prboom)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.prboom?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-prboom)
commit 61b15a429153918835ccf34aead4ba13b0e4c2a2
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:05 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:05 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index b162621..917acf4 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.prosystem addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Atari 7800.
+This is a [Kodi](http://kodi.tv) game addon for Atari - 7800 (ProSystem).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.prosystem?branch=master)](https://travis-ci.org/kodi-game/game.libretro.prosystem)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.prosystem.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.prosystem)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.prosystem?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-prosystem)
commit c71bd90f51ab26001551e5a64522c0b4f0bcf007
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:06 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:06 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 3c489d9..ebf3c2d 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.quicknes addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for NES.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - NES / Famicom (QuickNES).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.quicknes?branch=master)](https://travis-ci.org/kodi-game/game.libretro.quicknes)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.quicknes.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.quicknes)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.quicknes?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-quicknes)
commit 55f43834aa23d7d99af35c24f292efd070db4bca
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:06 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:06 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 275d415..9e3dbdf 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.reicast addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Sega Dreamcast.
+This is a [Kodi](http://kodi.tv) game addon for Sega - Dreamcast (Reicast).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.reicast?branch=master)](https://travis-ci.org/kodi-game/game.libretro.reicast)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.reicast.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.reicast)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.reicast?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-reicast)
commit 42e3feb262a2b211149b67e1642ad545d2aaf529
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:06 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:06 2018 +0100

    Updated by kodi-game-scripting

diff --git a/.travis.yml b/.travis.yml
new file mode 100644
index 0000000..5ab2966
--- /dev/null
+++ b/.travis.yml
@@ -0,0 +1,50 @@
+language: cpp
+
+#
+# Define the build matrix
+#
+# Travis defaults to building on Ubuntu Precise when building on
+# Linux. We need Trusty in order to get up to date versions of
+# cmake and g++.
+#
+env:
+  global:
+    - app_id=game.libretro.sameboy
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: gcc
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: clang
+    - os: osx
+      osx_image: xcode7.3
+    - os: osx
+      osx_image: xcode6.4
+
+#
+# Some of the OS X images don't have cmake, contrary to what people
+# on the Internet say
+#
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew update        ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew install cmake ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew upgrade cmake || true; fi
+
+#
+# The addon source is automatically checked out in $TRAVIS_BUILD_DIR,
+# we'll put the Kodi source on the same level
+#
+before_script:
+  - cd $TRAVIS_BUILD_DIR/..
+  - git clone --depth=1 https://github.com/xbmc/xbmc.git
+  - cd ${app_id} && mkdir build && cd build
+  - mkdir -p definition/${app_id}
+  - echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt
+  - cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons
+
+script: make
diff --git a/README.md b/README.md
index 7cdf5b2..390963e 100644
--- a/README.md
+++ b/README.md
@@ -1 +1,6 @@
-# game.libretro.sameboy
\ No newline at end of file
+# game.libretro.sameboy addon for Kodi
+
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - Game Boy / Color (SameBoy).
+
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.sameboy.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.sameboy)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.sameboy?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-sameboy)
diff --git a/appveyor.yml b/appveyor.yml
new file mode 100644
index 0000000..b71e30b
--- /dev/null
+++ b/appveyor.yml
@@ -0,0 +1,29 @@
+version: BuildNr.{build}
+
+image: Visual Studio 2015
+
+shallow_clone: true
+
+clone_folder: c:\projects\game.libretro.sameboy
+
+environment:
+  app_id: game.libretro.sameboy
+
+  matrix:
+    - GENERATOR: "Visual Studio 14"
+      CONFIG: Release
+    - GENERATOR: "Visual Studio 14 Win64"
+      CONFIG: Release
+
+build_script:
+  - cd ..
+  - git clone --depth=1 https://github.com/xbmc/xbmc.git
+  - mklink /j xbmc\project\BuildDependencies\msys64 C:\msys64
+  - cd %app_id%
+  - mkdir build
+  - cd build
+  - mkdir -p definition\%app_id%
+  - echo %app_id% %APPVEYOR_BUILD_FOLDER% %APPVEYOR_REPO_COMMIT% > definition\%app_id%\%app_id%.txt
+  - SET PATH=C:\Program Files (x86)\CMake\bin;C:\msys64\bin;C:\msys64\usr\bin;%PATH%
+  - cmake -T host=x64 -G "%GENERATOR%" -DADDONS_TO_BUILD=%app_id% -DCMAKE_BUILD_TYPE=%CONFIG% -DADDONS_DEFINITION_DIR=%APPVEYOR_BUILD_FOLDER%/build/definition -DADDON_SRC_PREFIX=../.. -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons
+  - cmake --build . --config %CONFIG% --target %app_id%
commit 9252020127d01a594ba328ac85e80a1c79f7e646
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:06 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:06 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 612ea34..4bc4a53 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.scummvm addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for PC adventure games.
+This is a [Kodi](http://kodi.tv) game addon for ScummVM.
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.scummvm?branch=master)](https://travis-ci.org/kodi-game/game.libretro.scummvm)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.scummvm.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.scummvm)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.scummvm?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-scummvm)
commit 60a51db14439b831b7b677d2d699d7de9a72469b
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:06 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:06 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 42c683e..e74d221 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.snes9x addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for SNES.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - SNES / Famicom (Snes9x).
 
 [![Build Status](https://travis-ci.org/kodi-game/game.libretro.snes9x.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.snes9x)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/garbear/game.libretro.snes9x?svg=true)](https://ci.appveyor.com/project/garbear/game-libretro-snes9x)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.snes9x?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-snes9x)
commit f8386ca2a349526bf24096189602f5a45f2952e3
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:06 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:06 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index b1bc83d..cf41410 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.snes9x2002 addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for SNES.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - SNES / Famicom (Snes9x 2002).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.snes9x2002?branch=master)](https://travis-ci.org/kodi-game/game.libretro.snes9x2002)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.snes9x2002.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.snes9x2002)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.snes9x2002?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-snes9x2002)
commit be560a56ae3ce4abb080d8cb736ea03468060a9e
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:06 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:06 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index dde926b..459bded 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.snes9x2010 addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for SNES.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - SNES / Famicom (Snes9x 2010).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.snes9x2010?branch=master)](https://travis-ci.org/kodi-game/game.libretro.snes9x2010)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.snes9x2010.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.snes9x2010)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.snes9x2010?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-snes9x2010)
commit de8b8b259d511cc33f22ca68c54b229e36353492
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:06 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:06 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 61031f3..65bc9d6 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.stella addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Atari 2600.
+This is a [Kodi](http://kodi.tv) game addon for Atari - 2600 (Stella).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.stella?branch=master)](https://travis-ci.org/kodi-game/game.libretro.stella)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.stella.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.stella)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.stella?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-stella)
commit 5bd7e177a8373e2ffbd4f1cc3fe945d4fa005537
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:06 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:06 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 1d57c20..543c3fb 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.tgbdual addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Game Boy (Color).
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - Game Boy / Color (TGB Dual).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.tgbdual?branch=master)](https://travis-ci.org/kodi-game/game.libretro.tgbdual)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.tgbdual.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.tgbdual)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.tgbdual?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-tgbdual)
commit 91588cfdbbba20a2d975c8684c659fd61b6df3fd
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:07 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:07 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index ad1c502..9c55f08 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.tyrquake addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon.
+This is a [Kodi](http://kodi.tv) game addon for Quake 1 (TyrQuake).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.tyrquake?branch=master)](https://travis-ci.org/kodi-game/game.libretro.tyrquake)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.tyrquake.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.tyrquake)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.tyrquake?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-tyrquake)
commit ea9eaa2b348d13cac45b66997c65352b7307edff
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:07 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:07 2018 +0100

    Updated by kodi-game-scripting

diff --git a/.travis.yml b/.travis.yml
new file mode 100644
index 0000000..e802eaa
--- /dev/null
+++ b/.travis.yml
@@ -0,0 +1,50 @@
+language: cpp
+
+#
+# Define the build matrix
+#
+# Travis defaults to building on Ubuntu Precise when building on
+# Linux. We need Trusty in order to get up to date versions of
+# cmake and g++.
+#
+env:
+  global:
+    - app_id=game.libretro.uae
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: gcc
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: clang
+    - os: osx
+      osx_image: xcode7.3
+    - os: osx
+      osx_image: xcode6.4
+
+#
+# Some of the OS X images don't have cmake, contrary to what people
+# on the Internet say
+#
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew update        ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew install cmake ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew upgrade cmake || true; fi
+
+#
+# The addon source is automatically checked out in $TRAVIS_BUILD_DIR,
+# we'll put the Kodi source on the same level
+#
+before_script:
+  - cd $TRAVIS_BUILD_DIR/..
+  - git clone --depth=1 https://github.com/xbmc/xbmc.git
+  - cd ${app_id} && mkdir build && cd build
+  - mkdir -p definition/${app_id}
+  - echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt
+  - cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons
+
+script: make
diff --git a/README.md b/README.md
index be932fa..82d3f97 100644
--- a/README.md
+++ b/README.md
@@ -1 +1,6 @@
-# game.libretro.uae
\ No newline at end of file
+# game.libretro.uae addon for Kodi
+
+This is a [Kodi](http://kodi.tv) game addon for Commodore - Amiga (P-UAE).
+
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.uae.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.uae)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.uae?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-uae)
diff --git a/appveyor.yml b/appveyor.yml
new file mode 100644
index 0000000..f6c9030
--- /dev/null
+++ b/appveyor.yml
@@ -0,0 +1,29 @@
+version: BuildNr.{build}
+
+image: Visual Studio 2015
+
+shallow_clone: true
+
+clone_folder: c:\projects\game.libretro.uae
+
+environment:
+  app_id: game.libretro.uae
+
+  matrix:
+    - GENERATOR: "Visual Studio 14"
+      CONFIG: Release
+    - GENERATOR: "Visual Studio 14 Win64"
+      CONFIG: Release
+
+build_script:
+  - cd ..
+  - git clone --depth=1 https://github.com/xbmc/xbmc.git
+  - mklink /j xbmc\project\BuildDependencies\msys64 C:\msys64
+  - cd %app_id%
+  - mkdir build
+  - cd build
+  - mkdir -p definition\%app_id%
+  - echo %app_id% %APPVEYOR_BUILD_FOLDER% %APPVEYOR_REPO_COMMIT% > definition\%app_id%\%app_id%.txt
+  - SET PATH=C:\Program Files (x86)\CMake\bin;C:\msys64\bin;C:\msys64\usr\bin;%PATH%
+  - cmake -T host=x64 -G "%GENERATOR%" -DADDONS_TO_BUILD=%app_id% -DCMAKE_BUILD_TYPE=%CONFIG% -DADDONS_DEFINITION_DIR=%APPVEYOR_BUILD_FOLDER%/build/definition -DADDON_SRC_PREFIX=../.. -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons
+  - cmake --build . --config %CONFIG% --target %app_id%
commit b24b97cbe378c9025fa320c9c55237ea3cb56821
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:07 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:07 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index e5d0eae..b444193 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.vbam addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Game Boy Advance.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - Game Boy Advance (VBA-M).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.vbam?branch=master)](https://travis-ci.org/kodi-game/game.libretro.vbam)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.vbam.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.vbam)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.vbam?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-vbam)
commit 162946765afa2776e5eb2a864aef55888199a509
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:07 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:07 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index c3dab10..6d8170b 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.vba-next addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Game Boy Advance.
+This is a [Kodi](http://kodi.tv) game addon for Nintendo - Game Boy Advance (VBA Next).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.vba-next?branch=master)](https://travis-ci.org/kodi-game/game.libretro.vba-next)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.vba-next.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.vba-next)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.vba-next?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-vba-next)
commit eef28acfd5553436da80ce224e1c3f1a8b86782d
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:07 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:07 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 7f6dd01..37fdfcf 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.vecx addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Vectrex.
+This is a [Kodi](http://kodi.tv) game addon for GCE - Vectrex (vecx).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.vecx?branch=master)](https://travis-ci.org/kodi-game/game.libretro.vecx)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.vecx.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.vecx)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.vecx?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-vecx)
commit 4dae5918ddd991ff23221a9ad00668c6334d1ace
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:07 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:07 2018 +0100

    Updated by kodi-game-scripting

diff --git a/.travis.yml b/.travis.yml
new file mode 100644
index 0000000..66b83fe
--- /dev/null
+++ b/.travis.yml
@@ -0,0 +1,50 @@
+language: cpp
+
+#
+# Define the build matrix
+#
+# Travis defaults to building on Ubuntu Precise when building on
+# Linux. We need Trusty in order to get up to date versions of
+# cmake and g++.
+#
+env:
+  global:
+    - app_id=game.libretro.vice
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: gcc
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: clang
+    - os: osx
+      osx_image: xcode7.3
+    - os: osx
+      osx_image: xcode6.4
+
+#
+# Some of the OS X images don't have cmake, contrary to what people
+# on the Internet say
+#
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew update        ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which cmake || brew install cmake ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew upgrade cmake || true; fi
+
+#
+# The addon source is automatically checked out in $TRAVIS_BUILD_DIR,
+# we'll put the Kodi source on the same level
+#
+before_script:
+  - cd $TRAVIS_BUILD_DIR/..
+  - git clone --depth=1 https://github.com/xbmc/xbmc.git
+  - cd ${app_id} && mkdir build && cd build
+  - mkdir -p definition/${app_id}
+  - echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt
+  - cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons
+
+script: make
diff --git a/README.md b/README.md
index 10d8279..243e656 100644
--- a/README.md
+++ b/README.md
@@ -1 +1,6 @@
-# game.libretro.vice
\ No newline at end of file
+# game.libretro.vice addon for Kodi
+
+This is a [Kodi](http://kodi.tv) game addon for Commodore - C64 (VICE C64).
+
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.vice.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.vice)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.vice?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-vice)
diff --git a/appveyor.yml b/appveyor.yml
new file mode 100644
index 0000000..d6ca58c
--- /dev/null
+++ b/appveyor.yml
@@ -0,0 +1,29 @@
+version: BuildNr.{build}
+
+image: Visual Studio 2015
+
+shallow_clone: true
+
+clone_folder: c:\projects\game.libretro.vice
+
+environment:
+  app_id: game.libretro.vice
+
+  matrix:
+    - GENERATOR: "Visual Studio 14"
+      CONFIG: Release
+    - GENERATOR: "Visual Studio 14 Win64"
+      CONFIG: Release
+
+build_script:
+  - cd ..
+  - git clone --depth=1 https://github.com/xbmc/xbmc.git
+  - mklink /j xbmc\project\BuildDependencies\msys64 C:\msys64
+  - cd %app_id%
+  - mkdir build
+  - cd build
+  - mkdir -p definition\%app_id%
+  - echo %app_id% %APPVEYOR_BUILD_FOLDER% %APPVEYOR_REPO_COMMIT% > definition\%app_id%\%app_id%.txt
+  - SET PATH=C:\Program Files (x86)\CMake\bin;C:\msys64\bin;C:\msys64\usr\bin;%PATH%
+  - cmake -T host=x64 -G "%GENERATOR%" -DADDONS_TO_BUILD=%app_id% -DCMAKE_BUILD_TYPE=%CONFIG% -DADDONS_DEFINITION_DIR=%APPVEYOR_BUILD_FOLDER%/build/definition -DADDON_SRC_PREFIX=../.. -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons
+  - cmake --build . --config %CONFIG% --target %app_id%
commit 3c0bff7887425ed5ce8b3d9ebd04af39540cdbbb
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:07 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:07 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index 63d0117..993cf85 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.virtualjaguar addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Jaguar.
+This is a [Kodi](http://kodi.tv) game addon for Atari - Jaguar (Virtual Jaguar).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.virtualjaguar?branch=master)](https://travis-ci.org/kodi-game/game.libretro.virtualjaguar)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.virtualjaguar.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.virtualjaguar)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.virtualjaguar?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-virtualjaguar)
commit 3aafe7f3c289de4fb4ab4a17eac5118c600a1428
Author:     Christian Fetzer <fetzer.ch@gmail.com>
AuthorDate: Thu Mar 8 22:08:07 2018 +0100
Commit:     Christian Fetzer <fetzer.ch@gmail.com>
CommitDate: Thu Mar 8 22:08:07 2018 +0100

    Updated by kodi-game-scripting

diff --git a/README.md b/README.md
index e86349c..23592a5 100644
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # game.libretro.yabause addon for Kodi
 
-This is a [Kodi](http://kodi.tv) game addon for Sega Saturn.
+This is a [Kodi](http://kodi.tv) game addon for Sega - Saturn (Yabause).
 
-[![Build Status](https://travis-ci.org/kodi-game/game.libretro.yabause?branch=master)](https://travis-ci.org/kodi-game/game.libretro.vba-next)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.yabause?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-vba-next)
+[![Build Status](https://travis-ci.org/kodi-game/game.libretro.yabause.svg?branch=master)](https://travis-ci.org/kodi-game/game.libretro.yabause)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro.yabause?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro-yabause)
```