### PR TITLE
git_access: Switch from rate to core in GitHub API

### DIFF
--- a/kodi_game_scripting/git_access.py
+++ b/kodi_game_scripting/git_access.py
@@ -47,7 +47,7 @@ class Git:
                 else:
                     username, password = None, None
                 self._github = github.Github(username, password)
-            rate = self._github.get_rate_limit().rate
+            rate = self._github.get_rate_limit().core
             print("GitHub API Rate: limit: {}, remaining: {}, reset: {}"
                   .format(rate.limit, rate.remaining, rate.reset.isoformat()))
             if auth:


### PR DESCRIPTION
kodi-game-scripting/kodi_game_scripting/git_access.py:50:
DeprecationWarning: Call to deprecated function (or staticmethod) rate.
(
   The rate object is deprecated. If you're writing new API client code
   or updating existing code, you should use the core object instead of
   the rate object. The core object contains the same information that
   is present in the rate object.
)
rate = self._github.get_rate_limit().rate