### PR TITLE
git_access: Make sure we have a supported PyGithub version installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gitpython
 jinja2
 keyring
-PyGithub
+PyGithub>=1.43.2
 xmljson


### PR DESCRIPTION
The change from rate to core in 1f7a29f only works when using an up to
date PyGithub version.