### PR TITLE
templates: Download archive (instead of fetch via git)

### DIFF
--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -46,7 +46,7 @@ ADDONS = {
     'bsnes-mercury-performance': ('bsnes-mercury',              'Makefile',          '.',                 'target-libretro/jni', {'binary_dir': 'out', 'soname': 'bsnes_mercury_performance', 'jnisoname': 'libretro_bsnes_mercury_performance', 'cmake_options': 'profile=performance'}),
     'cap32':                     ('libretro-cap32',             'Makefile',          '.'  ,               'jni'),
     'desmume':                   ('desmume',                    'Makefile.libretro', 'desmume/src/frontend/libretro', 'desmume/src/frontend/libretro/jni'),
-    'chailove':                  ('libretro-chailove',          'Makefile',          '.',                 'jni'),
+    'chailove':                  ('libretro-chailove',          'Makefile',          '.',                 'jni', {'download_type': 'git'}),
     #'dolphin':                   ('dolphin',                    'Makefile',          'Source/Core/DolphinLibretro', 'Source/Core/DolphinLibretro/jni', {'binary_dir': 'Source/Core/DolphinLibretro'}),  # Longrunning, Switched to CMake
     'dinothawr':                 ('Dinothawr',                  'Makefile',          '.',                 'jni'),
     'dosbox':                    ('dosbox-libretro',            'Makefile.libretro', '.',                 'jni'),

--- a/templates/addon/depends/common/{{ game.name }}/{{ game.name }}.txt.j2
+++ b/templates/addon/depends/common/{{ game.name }}/{{ game.name }}.txt.j2
@@ -1,1 +1,5 @@
+{% if config.download_type == 'git' %}
 {{ game.name }} https://github.com/libretro/{{ repo | default(game.name) }} {{ repo_branch | default('master') }}
+{% else %}
+{{ game.name }} https://github.com/libretro/{{ repo | default(game.name) }}/archive/{{ repo_branch | default('master') }}.zip
+{% endif %}


### PR DESCRIPTION
This can massively decrease the amount of downloaded data.
This cannot be used for libretro cores that use Git submodules.

The change needs a modification in xbmc/xbmc:
```
diff --git a/cmake/scripts/common/HandleDepends.cmake b/cmake/scripts/common/HandleDepends.cmake
index 47f7d9b768..2fd9f70e0e 100644
--- a/cmake/scripts/common/HandleDepends.cmake
+++ b/cmake/scripts/common/HandleDepends.cmake
@@ -231,7 +231,7 @@ function(add_addon_depends addon searchpath)
                                     -DCMAKE_INCLUDE_PATH=${OUTPUT_DIR}/include)
             endif()
 
-            set(DOWNLOAD_DIR ${BUILD_DIR}/download)
+            set(DOWNLOAD_DIR ${BUILD_DIR}/${id}/download)
             if(EXISTS ${dir}/${id}.sha256)
               file(STRINGS ${dir}/${id}.sha256 sha256sum)
               list(GET sha256sum 0 sha256sum)
```

Needs: https://github.com/xbmc/xbmc/pull/14632