### PR TITLE
templates: install libgl1-mesa-dev on Travis CI if GL is used

### DIFF
--- a/templates/addon/.travis.yml.j2
+++ b/templates/addon/.travis.yml.j2
@@ -26,6 +26,12 @@ matrix:
     - os: osx
       osx_image: xcode9.3
 
+{% if library.opengl %}
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libgl1-mesa-dev; fi
+
+{% endif %}
 #
 # The addon source is automatically checked out in $TRAVIS_BUILD_DIR,
 # we'll put the Kodi source on the same level


### PR DESCRIPTION
Please push updates to desmume, mame2016, mupen64plus and reicast (without version bump and tagging) after merging this PR.