### PR TITLE
templates: fix trailing newlines in strings.po

### DIFF
--- a/templates/addon/{{ game.addon }}/resources/language/English/strings.po.j2
+++ b/templates/addon/{{ game.addon }}/resources/language/English/strings.po.j2
@@ -20,11 +20,10 @@ msgstr ""
 msgctxt "#30000"
 msgid "Settings"
 msgstr ""
-
 {% for setting in settings %}
+
 msgctxt "#{{ 30000 + loop.index }}"
 msgid "{{ setting.description }}"
 msgstr ""
-
 {% endfor %}
 {% endif %}

--- a/tests/integration/test_data/test_template_processor/addon/game.libretro.mygame/resources/language/English/strings.po
+++ b/tests/integration/test_data/test_template_processor/addon/game.libretro.mygame/resources/language/English/strings.po
@@ -27,4 +27,3 @@ msgstr ""
 msgctxt "#30002"
 msgid "mysetting2"
 msgstr ""
-


### PR DESCRIPTION
Fixes the trailing newlines the right way. #16 was reverted as most editors automatically add a new line at the end of file.