### PR TITLE
templates: fix finding libretro game library on windows

### DIFF
--- a/templates/addon/CMakeLists.txt.j2
+++ b/templates/addon/CMakeLists.txt.j2
@@ -4,7 +4,17 @@ project({{ game.addon }})
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 
 find_package(Kodi REQUIRED)
+
+# CMake on windows only searches for .lib libraries (static library or import library).
+# The libretro game library is dynamically loaded so even if an import library would exists it's of no use.
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  set(_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
+endif()
 find_library({{ game.name|upper }}_LIB NAMES {{ library.soname }}${CMAKE_SHARED_LIBRARY_SUFFIX} PATH_SUFFIXES libretro)
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${_CMAKE_FIND_LIBRARY_SUFFIXES})
+endif()
 
 set({{ game.name|upper }}_CUSTOM_BINARY {{ '${' }}{{ game.name|upper }}_LIB}
     ${PROJECT_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})

--- a/tests/integration/test_data/test_template_processor/addon/CMakeLists.txt
+++ b/tests/integration/test_data/test_template_processor/addon/CMakeLists.txt
@@ -4,7 +4,17 @@ project(game.libretro.mygame)
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 
 find_package(Kodi REQUIRED)
+
+# CMake on windows only searches for .lib libraries (static library or import library).
+# The libretro game library is dynamically loaded so even if an import library would exists it's of no use.
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  set(_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
+endif()
 find_library(MYGAME_LIB NAMES ${CMAKE_SHARED_LIBRARY_SUFFIX} PATH_SUFFIXES libretro)
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${_CMAKE_FIND_LIBRARY_SUFFIXES})
+endif()
 
 set(MYGAME_CUSTOM_BINARY ${MYGAME_LIB}
     ${PROJECT_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})


### PR DESCRIPTION
This fixes finding the shared libretro game library on windows after e80834b (#42).