### PR TITLE
templates: fix regex_replace for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 install: pip install tox
 script: tox
@@ -10,3 +11,5 @@ jobs:
       env: TOXENV=py36
       install: pip install tox coveralls
       after_success: coveralls
+    - python: 3.7
+      env: TOXENV=py37

--- a/templates/addon/{{ game.addon }}/addon.xml.in.j2
+++ b/templates/addon/{{ game.addon }}/addon.xml.in.j2
@@ -27,7 +27,7 @@
 		{% endif %}
 		<summary lang="en_GB">{{ summary | e }}</summary>
 		{% if system_info.extensions %}
-			{% set extensions = 'Supported files: ' + system_info.extensions | map('regex_replace', '(.*)', '.\\1') | join(', ') %}
+			{% set extensions = 'Supported files: ' + system_info.extensions | map('regex_replace', '(.+)', '.\\1') | join(', ') %}
 		{% endif %}
 		{% set description = xml.addon.extension[1].description.content | default('') %}
 		{% if ("Supported files: " in xml.addon.extension[1].description.content) %}


### PR DESCRIPTION
The behaviour of re.sub was changed in [bpo-32308](https://bugs.python.org/issue32308).